### PR TITLE
[4.0] Laravel 5 comes with Bootstrap 3

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -10,7 +10,7 @@
 	'default_form_type'       => 'horizontal',
 
 	// The framework to be used by Former
-	'framework'               => 'TwitterBootstrap',
+	'framework'               => 'TwitterBootstrap3',
 
 	// Validation
 	////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use Bootstrap 3 as default as it's what Laravel 5 comes with.